### PR TITLE
Updated compat, could go further with Julia v1, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,15 @@ version = "1.0.0"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Combinatorics = "≥ 0.6.0"
+Random = "≥ 0.7.0"
 StatsBase = "≥ 0.23.0"
 julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
Would like compat to update here: https://github.com/JuliaRegistries/General/blob/master/M/MotifSequenceGenerator/Compat.toml

This limits StatsBase to v0.33 (currently on v0.34)